### PR TITLE
홀/짝 게임 로직 구현

### DIFF
--- a/src/main/java/dev/codehouse/backend/BackendApplication.java
+++ b/src/main/java/dev/codehouse/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package dev.codehouse.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/dev/codehouse/backend/game/controller/OddEvenController.java
+++ b/src/main/java/dev/codehouse/backend/game/controller/OddEvenController.java
@@ -1,0 +1,33 @@
+package dev.codehouse.backend.game.controller;
+
+
+import dev.codehouse.backend.game.dto.BetSummaryResponseDto;
+import dev.codehouse.backend.game.dto.OddEvenRequestDto;
+import dev.codehouse.backend.game.service.OddEvenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/oddeven")
+@RequiredArgsConstructor
+public class OddEvenController {
+
+    private final OddEvenService oddEvenService;
+
+    @PostMapping("/bet")
+    public void bet(@RequestBody OddEvenRequestDto dto) {
+        oddEvenService.bet(dto);
+    }
+
+    @GetMapping("/roundSummary/{username}")
+    public BetSummaryResponseDto getCurrentRoundSummary(@PathVariable String username) {
+        return oddEvenService.getCurrentRoundResult(username);
+    }
+
+
+    @PostMapping("/calculate")
+    public void calculate() {
+        oddEvenService.calculateResult();
+    }
+}
+

--- a/src/main/java/dev/codehouse/backend/game/domain/Bet.java
+++ b/src/main/java/dev/codehouse/backend/game/domain/Bet.java
@@ -1,0 +1,17 @@
+package dev.codehouse.backend.game.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Bet {
+    private String username;
+    private int betAmount;
+    private String betType; // "odd" or "even"
+}

--- a/src/main/java/dev/codehouse/backend/game/dto/BetSummaryResponseDto.java
+++ b/src/main/java/dev/codehouse/backend/game/dto/BetSummaryResponseDto.java
@@ -1,0 +1,30 @@
+package dev.codehouse.backend.game.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BetSummaryResponseDto {
+    private String round;
+    private SideSummary even;
+    private SideSummary odd;
+    private MyBetDto myBet;
+    private String resultType;
+
+    @Getter
+    @AllArgsConstructor
+    public static class SideSummary {
+        private int totalBet;
+        private List<TopBettor> topBettors;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class TopBettor {
+        private String username;
+        private int amount;
+    }
+}

--- a/src/main/java/dev/codehouse/backend/game/dto/MyBetDto.java
+++ b/src/main/java/dev/codehouse/backend/game/dto/MyBetDto.java
@@ -1,0 +1,11 @@
+package dev.codehouse.backend.game.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyBetDto {
+    private String betType;
+    private int betAmount;
+}

--- a/src/main/java/dev/codehouse/backend/game/dto/OddEvenRequestDto.java
+++ b/src/main/java/dev/codehouse/backend/game/dto/OddEvenRequestDto.java
@@ -1,0 +1,14 @@
+package dev.codehouse.backend.game.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OddEvenRequestDto {
+    private String username;
+    private int betAmount;
+    private String betType; //홀 또는 짝 (odd or even)
+}

--- a/src/main/java/dev/codehouse/backend/game/repository/RedisRepository.java
+++ b/src/main/java/dev/codehouse/backend/game/repository/RedisRepository.java
@@ -1,0 +1,28 @@
+package dev.codehouse.backend.game.repository;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface RedisRepository {
+
+    void putBet(String key, String username, String betJson);
+
+    String getBet(String key, String username);
+
+    Map<String, String> getAllBets(String key);
+
+    void deleteBets(String key);
+
+    void addScoreToSortedSet(String key, String member, double score);
+
+    Set<String> getTopFromSortedSet(String key, int count);
+
+    void deleteSortedSet(String key);
+
+    void putResult(String resultKey, String resultType);
+
+    String getResult(String resultKey);
+
+    void deleteResult(String resultKey);
+
+}

--- a/src/main/java/dev/codehouse/backend/game/repository/RedisRepositoryImpl.java
+++ b/src/main/java/dev/codehouse/backend/game/repository/RedisRepositoryImpl.java
@@ -1,0 +1,79 @@
+package dev.codehouse.backend.game.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepositoryImpl implements RedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void putBet(String key, String username, String betJson) {
+        redisTemplate.opsForHash().put(key, username, betJson);
+    }
+
+    @Override
+    public String getBet(String key, String username) {
+        Object val = redisTemplate.opsForHash().get(key, username);
+        return val == null ? null : val.toString();
+    }
+
+    @Override
+    public Map<String, String> getAllBets(String key) {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+        if (entries == null || entries.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return entries.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        e -> e.getKey().toString(),
+                        e -> e.getValue().toString()
+                ));
+    }
+
+    @Override
+    public void deleteBets(String key) {
+        redisTemplate.delete(key);
+    }
+
+    @Override
+    public void addScoreToSortedSet(String key, String member, double score) {
+        redisTemplate.opsForZSet().incrementScore(key, member, score);
+    }
+
+    @Override
+    public Set<String> getTopFromSortedSet(String key, int count) {
+        Set<String> reversed = redisTemplate.opsForZSet().reverseRange(key, 0, count - 1);
+        return reversed == null ? Collections.emptySet() : reversed;
+    }
+
+    @Override
+    public void deleteSortedSet(String key) {
+        redisTemplate.delete(key);
+    }
+    @Override
+    public void putResult(String resultKey, String resultType) {
+        redisTemplate.opsForValue().set(resultKey, resultType);
+    }
+
+    @Override
+    public String getResult(String resultKey) {
+        return redisTemplate.opsForValue().get(resultKey);
+    }
+
+    @Override
+    public void deleteResult(String resultKey) {
+        redisTemplate.delete(resultKey);
+    }
+
+}

--- a/src/main/java/dev/codehouse/backend/game/schedular/GameScheduler.java
+++ b/src/main/java/dev/codehouse/backend/game/schedular/GameScheduler.java
@@ -17,4 +17,7 @@ public class GameScheduler {
     public void calculateResult() {
         oddEvenService.calculateResult();
     }
+
+    @Scheduled(cron="0 0 * * * *")
+    public void resetForNewRound(){oddEvenService.resetForNewRound();}
 }

--- a/src/main/java/dev/codehouse/backend/game/schedular/GameScheduler.java
+++ b/src/main/java/dev/codehouse/backend/game/schedular/GameScheduler.java
@@ -1,0 +1,20 @@
+package dev.codehouse.backend.game.schedular;
+
+import dev.codehouse.backend.game.service.GameService;
+import dev.codehouse.backend.game.service.OddEvenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GameScheduler {
+
+    private final OddEvenService oddEvenService;
+
+    //각 게임 결과 로직 서비스 추가 예정
+    @Scheduled(cron="0 50 * * * *")
+    public void calculateResult() {
+        oddEvenService.calculateResult();
+    }
+}

--- a/src/main/java/dev/codehouse/backend/game/service/GameService.java
+++ b/src/main/java/dev/codehouse/backend/game/service/GameService.java
@@ -1,0 +1,6 @@
+package dev.codehouse.backend.game.service;
+
+public interface GameService <T>{
+    void bet(T requestDto);
+    void calculateResult();
+}

--- a/src/main/java/dev/codehouse/backend/game/service/OddEvenService.java
+++ b/src/main/java/dev/codehouse/backend/game/service/OddEvenService.java
@@ -1,0 +1,250 @@
+package dev.codehouse.backend.game.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.codehouse.backend.game.domain.Bet;
+import dev.codehouse.backend.game.dto.BetSummaryResponseDto;
+import dev.codehouse.backend.game.dto.MyBetDto;
+import dev.codehouse.backend.game.dto.OddEvenRequestDto;
+import dev.codehouse.backend.game.repository.RedisRepository;
+import dev.codehouse.backend.user.domain.User;
+import dev.codehouse.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class OddEvenService implements GameService<OddEvenRequestDto> {
+
+    private final RedisRepository redisRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Random random = new Random();
+
+    // 라운드 키 - 시간 단위 (ex: 2025062017)
+    private String getCurrentRoundKey() {
+        LocalDateTime now = LocalDateTime.now();
+        return now.format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+
+    // 베팅 데이터 저장 키
+    private String getBetsKey(String roundKey) {
+        return "oddEven:" + roundKey + ":bets";
+    }
+
+    // 점수 저장 SortedSet 키
+    private String getScoreKey(String roundKey, String betType) {
+        return "oddEven:" + roundKey + ":score:" + betType.toLowerCase();
+    }
+
+    // 결과 저장 (홀짝 결과, 50분에 저장)
+    private String getResultKey(String roundKey) {
+        return "oddEven:" + roundKey + ":result";
+    }
+
+    // 베팅 가능 시간 00분~49분59초로 제한
+    private void validateBettingTime() {
+        int minute = LocalDateTime.now().getMinute();
+        if (minute >= 50) {
+            throw new IllegalStateException("베팅 가능 시간이 아닙니다. 00분부터 49분 59초까지만 베팅 가능합니다.");
+        }
+    }
+
+    // 배팅 처리
+    @Override
+    public void bet(OddEvenRequestDto dto) {
+        validateBettingTime();
+
+        String roundKey = getCurrentRoundKey();
+        String betsKey = getBetsKey(roundKey);
+
+        User user = userRepository.findByUsername(dto.getUsername())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다: " + dto.getUsername()));
+
+        if (user.getPoint() < dto.getBetAmount()) {
+            throw new IllegalArgumentException("포인트 부족");
+        }
+
+        Map<String, String> allBets = redisRepository.getAllBets(betsKey);
+
+        Bet updatedBet;
+
+        if (allBets != null && allBets.containsKey(dto.getUsername())) {
+            Bet existingBet;
+            try {
+                existingBet = objectMapper.readValue(allBets.get(dto.getUsername()), Bet.class);
+            } catch (Exception e) {
+                throw new RuntimeException("Redis 데이터 파싱 실패", e);
+            }
+
+            if (!existingBet.getBetType().equalsIgnoreCase(dto.getBetType())) {
+                throw new IllegalArgumentException("'" + existingBet.getBetType() + "'에 이미 배팅한 유저는 반대 방향에 배팅할 수 없습니다.");
+            }
+
+            int newAmount = existingBet.getBetAmount() + dto.getBetAmount();
+            updatedBet = new Bet(dto.getUsername(), newAmount, dto.getBetType());
+        } else {
+            updatedBet = new Bet(dto.getUsername(), dto.getBetAmount(), dto.getBetType());
+        }
+
+        user.setPoint(user.getPoint() - dto.getBetAmount());
+        userRepository.save(user);
+
+        String betJson;
+        try {
+            betJson = objectMapper.writeValueAsString(updatedBet);
+        } catch (Exception e) {
+            throw new RuntimeException("베팅 데이터 직렬화 실패", e);
+        }
+        redisRepository.putBet(betsKey, dto.getUsername(), betJson);
+
+        String scoreKey = getScoreKey(roundKey, dto.getBetType());
+        redisRepository.addScoreToSortedSet(scoreKey, dto.getUsername(), dto.getBetAmount());
+    }
+
+    /**
+     * 50분에 호출되는 결과 계산 메서드
+     * 1) 현재 라운드(시 단위)의 베팅 데이터 조회
+     * 2) 랜덤 홀짝 결과 생성 후 Redis에 저장 (resultKey)
+     * 3) 맞춘 유저에게 포인트 지급
+     * 4) 베팅 데이터 및 점수 데이터 삭제 (새 라운드 전용)
+     */
+    @Override
+    public void calculateResult() {
+        String roundKey = getCurrentRoundKey();
+        String betsKey = getBetsKey(roundKey);
+
+        Map<String, String> allBets = redisRepository.getAllBets(betsKey);
+        if (allBets == null || allBets.isEmpty()) return;
+
+        int resultNumber = random.nextInt(100) + 1;
+        boolean isEven = (resultNumber % 2 == 0);
+
+        String resultType = isEven ? "even" : "odd";
+
+        redisRepository.putResult(getResultKey(roundKey), resultType);
+
+        //점수 분배
+        for (String betJson : allBets.values()) {
+            Bet bet;
+            try {
+                bet = objectMapper.readValue(betJson, Bet.class);
+            } catch (Exception e) {
+                throw new RuntimeException("Redis 데이터 파싱 실패", e);
+            }
+
+            User user = userRepository.findByUsername(bet.getUsername())
+                    .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다: " + bet.getUsername()));
+
+            boolean userChoseEven = bet.getBetType().equalsIgnoreCase("even");
+            if (userChoseEven == isEven) {
+                //배당 내용(수정 예정)
+                user.setPoint(user.getPoint() + bet.getBetAmount() * 2);
+            }
+
+            userRepository.save(user);
+        }
+
+        redisRepository.deleteBets(betsKey);
+        redisRepository.deleteSortedSet(getScoreKey(roundKey, "odd"));
+        redisRepository.deleteSortedSet(getScoreKey(roundKey, "even"));
+    }
+
+    /**
+     * 00분에 호출되는 메서드 (새로운 라운드 시작 전 초기화)
+     * 이전 라운드 결과 및 베팅 정보 삭제
+     */
+    public void resetForNewRound() {
+        String previousRoundKey = getCurrentRoundKey();
+
+        // 베팅, 점수, 결과 모두 삭제
+        redisRepository.deleteBets(getBetsKey(previousRoundKey));
+        redisRepository.deleteSortedSet(getScoreKey(previousRoundKey, "odd"));
+        redisRepository.deleteSortedSet(getScoreKey(previousRoundKey, "even"));
+        redisRepository.deleteResult(getResultKey(previousRoundKey));
+    }
+
+    /**
+     * 50분~59분 사이에 결과를 조회할 때 호출
+     * Redis에 저장된 결과를 가져와서 반환
+     * 결과가 없으면 빈 데이터 반환
+     */
+    public BetSummaryResponseDto getCurrentRoundResult(String username) {
+        LocalDateTime now = LocalDateTime.now();
+        int minute = now.getMinute();
+
+        if (minute < 50) {
+            return new BetSummaryResponseDto(
+                    getCurrentRoundKey(),
+                    new BetSummaryResponseDto.SideSummary(0, List.of()),
+                    new BetSummaryResponseDto.SideSummary(0, List.of()),
+                    null,
+                    null // 결과 홀 또는 짝
+            );
+        }
+
+        String roundKey = getCurrentRoundKey();
+        String betsKey = getBetsKey(roundKey);
+        String resultKey = getResultKey(roundKey);
+
+        String resultType = redisRepository.getResult(resultKey);
+        if (resultType == null) {
+            return new BetSummaryResponseDto(
+                    roundKey,
+                    new BetSummaryResponseDto.SideSummary(0, List.of()),
+                    new BetSummaryResponseDto.SideSummary(0, List.of()),
+                    null,
+                    null
+            );
+        }
+
+        Map<String, String> allBets = redisRepository.getAllBets(betsKey);
+        if (allBets == null) allBets = Collections.emptyMap();
+
+        Map<String, Integer> oddBets = new HashMap<>();
+        Map<String, Integer> evenBets = new HashMap<>();
+        MyBetDto myBet = null;
+
+        for (Map.Entry<String, String> entry : allBets.entrySet()) {
+            try {
+                Bet bet = objectMapper.readValue(entry.getValue(), Bet.class);
+                if ("odd".equalsIgnoreCase(bet.getBetType())) {
+                    oddBets.merge(bet.getUsername(), bet.getBetAmount(), Integer::sum);
+                } else if ("even".equalsIgnoreCase(bet.getBetType())) {
+                    evenBets.merge(bet.getUsername(), bet.getBetAmount(), Integer::sum);
+                }
+                if (bet.getUsername().equals(username)) {
+                    myBet = new MyBetDto(bet.getBetType(), bet.getBetAmount());
+                }
+            } catch (Exception e) {
+            }
+        }
+
+        BetSummaryResponseDto.SideSummary oddSummary = summarize(oddBets);
+        BetSummaryResponseDto.SideSummary evenSummary = summarize(evenBets);
+
+        return new BetSummaryResponseDto(
+                roundKey,
+                evenSummary,
+                oddSummary,
+                myBet,
+                resultType // 홀짝 결과
+        );
+    }
+
+
+    private BetSummaryResponseDto.SideSummary summarize(Map<String, Integer> userBets) {
+        int total = userBets.values().stream().mapToInt(Integer::intValue).sum();
+
+        List<BetSummaryResponseDto.TopBettor> top = userBets.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .limit(5)
+                .map(e -> new BetSummaryResponseDto.TopBettor(e.getKey(), e.getValue()))
+                .toList();
+
+        return new BetSummaryResponseDto.SideSummary(total, top);
+    }
+}

--- a/src/main/java/dev/codehouse/backend/global/config/RedisConfig.java
+++ b/src/main/java/dev/codehouse/backend/global/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package dev.codehouse.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        // key 직렬화 - 문자열
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+
+        // value 직렬화 - JSON
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}
+


### PR DESCRIPTION
# 🃏 홀짝 게임 (Odd-Even Game) - 기능 상세 설명 및 동작 흐름

## 1. 개요

홀짝 게임은 사용자가 ‘홀(odd)’ 또는 ‘짝(even)’ 중 하나를 선택하여 포인트를 베팅하고,  
**매 시각 50분에 무작위 숫자를 생성해 홀짝 여부를 결정**합니다.  
결과가 발표되면 **맞춘 사용자에게 베팅 금액의 두 배를 지급**하는 베팅 게임입니다.

---

## 2. 라운드 관리 및 시간 제약

- **라운드 구분**
  - 라운드는 매 시간 단위별로 구분되며, 키는 `yyyyMMddHH` 형식으로 구성됩니다.
  - 예: `2025062017` → 2025년 6월 20일 17시 라운드

- **베팅 가능 시간**
  - 매 시각 `00:00 ~ 49:59`까지만 베팅 가능
  - **50분 이후는 베팅 불가**, 결과 발표 및 조회만 가능

- **결과 발표 및 초기화**
  - **50분**에 무작위 숫자를 통해 결과 산출 → Redis 저장
  - **00분**에 이전 라운드 데이터를 모두 삭제 → 새로운 라운드 준비 완료

---

## 3. API별 상세 기능 및 주소

### ✅ 3-1. 베팅 처리 - `POST /oddeven/bet`

- **설명**: 사용자가 ‘홀’ 또는 ‘짝’에 포인트를 베팅합니다.

- **요청 예시**
  ```json
  {
    "username": "player1",
    "betType": "odd",
    "betAmount": 1000
  }
## ✅ 처리 흐름

### 🔹 베팅 처리 - `POST /oddeven/bet`

- **현재 시간이 `00~49분`인지 검증**
- 사용자 존재 여부 및 포인트 잔액 확인
- Redis에서 현재 라운드 베팅 내역 조회
- 이미 반대편에 베팅한 경우 예외 발생
- 기존 베팅이 있으면 금액 누적 / 신규 베팅이면 새로 저장
- 사용자 포인트 차감 및 저장
- Redis에 다음과 같이 저장:
  - `Hash` → 베팅 정보 저장 (`oddEven:{roundKey}:bets`)
  - `SortedSet` → 유저별 베팅 금액 누적 점수 저장 (`oddEven:{roundKey}:score:{betType}`)

---

### 📊 결과 조회 - `GET /oddeven/roundSummary/{username}`

- **설명**: 현재 라운드의 결과 및 전체 베팅 현황을 조회
- **경로 변수**: `username` (조회할 사용자 이름)

- **처리 흐름**
  - `50분 이전`에 호출한 경우 → 빈 결과 반환
  - `50분 이후` 호출 시:
    - Redis에서 홀/짝 베팅 총액 조회
    - 각 베팅에 대해 상위 5명 유저 리스트 추출
    - 요청자의 베팅 정보 포함
    - 이번 라운드의 결과 (`"odd"` 또는 `"even"`) 포함

---

### 🧮 결과 산출 - `POST /oddeven/calculate` *(스케줄러 자동 호출)*

- **설명**: 매 시각 50분에 스케줄러가 자동 호출되어 결과를 계산합니다.

- **처리 흐름**
  - Redis에서 현재 라운드 베팅 내역 조회
  - `1~100 사이 무작위 숫자 생성` → 홀짝 여부 결정
  - 결과를 Redis에 저장 (`oddEven:{roundKey}:result`)
  - 맞춘 유저에게 `베팅 금액 × 2` 포인트 지급
  - Redis에서 베팅 정보 및 점수 데이터 삭제

---

## ⏱ 스케줄러 연동

// ✅ GameScheduler.java

```java
@Component
@RequiredArgsConstructor
public class GameScheduler {

    private final OddEvenService oddEvenService;

    // 매 시각 50분: 결과 산출
    @Scheduled(cron = "0 50 * * * *")
    public void calculateResult() {
        oddEvenService.calculateResult();
    }

    // 매 시각 00분: 이전 라운드 데이터 초기화
    @Scheduled(cron = "0 0 * * * *")
    public void resetForNewRound() {
        oddEvenService.resetForNewRound();
    }
}
```

 💡 **스케줄러 작동 개요**

 - `@Scheduled(cron = "0 50 * * * *")`  
   → 매 시각 **50분 정각**에 실행되어 **베팅 결과를 산출**합니다.

 - `@Scheduled(cron = "0 0 * * * *")`  
   → 매 시각 **정각(00분)**에 실행되어 **이전 라운드 데이터를 초기화**합니다.

 이 두 작업은 Spring의 `@Scheduled` 어노테이션을 활용한 자동화 처리입니다.

## 5. 🧾 Redis 키 구조 및 역할

| Redis 키 패턴                     | 자료구조   | 설명                                                  |
|----------------------------------|------------|--------------------------------------------------------|
| `oddEven:{roundKey}:bets`        | Hash       | 유저별 베팅 정보 저장 (`username → Bet` JSON)         |
| `oddEven:{roundKey}:score:odd`   | SortedSet  | 홀(odd) 베팅자별 누적 점수 저장                       |
| `oddEven:{roundKey}:score:even`  | SortedSet  | 짝(even) 베팅자별 누적 점수 저장                      |
| `oddEven:{roundKey}:result`      | String     | 해당 라운드의 게임 결과 저장 (`"odd"` 또는 `"even"`) |

---

## 6. ❗ 예외 및 검증 처리

- ⛔ **베팅 시간 외 요청**  
  - 50분 이후에는 베팅 불가 → `IllegalStateException`

- ❌ **반대편 중복 베팅**  
  - 이미 홀/짝에 베팅한 유저가 반대편 선택 시 → `IllegalArgumentException`

- ❗ **포인트 부족 or 유저 없음**  
  - 존재하지 않는 사용자이거나 포인트 부족 시 → 예외 발생

- ⚠️ **Redis 데이터 파싱 오류**  
  - Redis에 저장된 JSON 파싱 실패 시 → 런타임 예외 발생

---

## 7. 🧩 주요 컴포넌트 역할 정리

| 컴포넌트              | 역할 설명                                                   |
|-----------------------|--------------------------------------------------------------|
| `OddEvenController`   | REST API 엔드포인트 제공 및 클라이언트 요청 분기 처리        |
| `OddEvenService`      | 베팅 처리, 결과 계산, 결과 조회 등 비즈니스 로직 담당        |
| `GameScheduler`       | 매 시각 00분 / 50분에 자동으로 게임 흐름 스케줄링 관리       |
| `RedisRepository`     | Redis 데이터 저장/조회/삭제 등 연동 처리                    |
| DTO / 도메인 객체들  | API 요청/응답 구조 정의 및 내부 데이터 모델 표현             |
